### PR TITLE
fix(kv-offload): support LLVM 22 RDMA bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.4",
+ "rustix",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -365,25 +365,22 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "lazy_static",
- "lazycell",
+ "itertools 0.10.5",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.117",
- "which",
 ]
 
 [[package]]
@@ -728,7 +725,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -973,7 +970,7 @@ dependencies = [
  "crossterm_winapi",
  "document-features",
  "parking_lot",
- "rustix 1.1.4",
+ "rustix",
  "winapi",
 ]
 
@@ -1419,7 +1416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1953,15 +1950,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,7 +2342,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2408,7 +2396,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2499,12 +2487,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,12 +2532,6 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3290,6 +3266,7 @@ dependencies = [
  "log",
  "openinfer-kv-cache",
  "pegaflow-core",
+ "rdma-mummy-sys",
  "tokio",
  "tokio-stream",
  "xxhash-rust",
@@ -3672,12 +3649,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "pegaflow-common"
 version = "0.23.3"
 source = "git+https://github.com/novitalabs/pegaflow.git?rev=1473c5355d879b4fea23101760cb2a0074642ada#1473c5355d879b4fea23101760cb2a0074642ada"
@@ -3864,7 +3835,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -4358,9 +4329,9 @@ dependencies = [
 
 [[package]]
 name = "rdma-mummy-sys"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8ead4d7835190d761b9365d9e53906a226d7699007b35bdca49d7edb89a15"
+checksum = "7366fa21da4b5cb28f6301888f126770e87cbf8ec6400fe4b7c5d7ee7c5faa5c"
 dependencies = [
  "bindgen",
  "cmake",
@@ -4638,19 +4609,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -4658,8 +4616,8 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5463,8 +5421,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6745,18 +6703,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "win-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6798,7 +6744,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6895,15 +6841,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/openinfer-kv-offload/Cargo.toml
+++ b/openinfer-kv-offload/Cargo.toml
@@ -25,6 +25,9 @@ openinfer-kv-cache = { workspace = true }
 pegaflow-core = { git = "https://github.com/novitalabs/pegaflow.git", rev = "1473c5355d879b4fea23101760cb2a0074642ada", default-features = false, features = [
   "rdma",
 ] }
+# pegaflow accepts rdma-mummy-sys 0.2.4, whose bindgen version emits opaque
+# ibverbs structs with LLVM 22. Require 0.2.5 until pegaflow raises its floor.
+rdma-mummy-sys = "0.2.5"
 tokio = { workspace = true }
 tokio-stream = { workspace = true, features = ["net"] }
 xxhash-rust = { workspace = true }

--- a/openinfer-kv-offload/tests/rdma_bindings.rs
+++ b/openinfer-kv-offload/tests/rdma_bindings.rs
@@ -1,0 +1,8 @@
+use rdma_mummy_sys::ibv_context;
+use rdma_mummy_sys::ibv_mr;
+
+#[test]
+fn generated_verbs_structs_are_not_opaque() {
+    assert!(std::mem::offset_of!(ibv_context, ops) < std::mem::size_of::<ibv_context>());
+    assert!(std::mem::offset_of!(ibv_mr, lkey) < std::mem::size_of::<ibv_mr>());
+}


### PR DESCRIPTION
## Summary

- Require `rdma-mummy-sys` 0.2.5 directly in `openinfer-kv-offload`.
  The pinned `pegaflow-core` revision permits 0.2.4, so this requirement
  raises the resolver's minimum version.
- Update `Cargo.lock` to `rdma-mummy-sys` 0.2.5. Its bindgen update removes
  obsolete transitive dependencies from the lockfile.
- Add a compile regression test that accesses `ibv_context.ops` and
  `ibv_mr.lkey`.

## Motivation

With LLVM/libclang 22, bindgen 0.66 generates vendored rdma-core structs such
as `ibv_context` as opaque `_address` shells. `rdma-mummy-sys` 0.2.4 then
fails to compile when its wrapper accesses fields such as `ops`, `context`,
and `lkey`.

`rdma-mummy-sys` 0.2.5 upgrades bindgen to 0.72.1 to support LLVM 22
([upstream commit](https://github.com/RDMA-Rust/rdma-mummy-sys/commit/a0e8d7993800a1736243b6dcab65220306a88fae)).

## Impact

OpenInfer now builds when bindgen loads libclang 22, without overriding
`LIBCLANG_PATH` to select an older installation. RDMA runtime behavior is
unchanged.

## Validation

- `cargo fmt --check`
- `env -u LIBCLANG_PATH CUDA_HOME=/opt/cuda cargo check --release -p openinfer-server`
- `env -u LIBCLANG_PATH CUDA_HOME=/opt/cuda cargo test --release -p openinfer-kv-offload --test rdma_bindings`

The release check and regression test pass with libclang 22.
