### PR TITLE
chore(frontend): bump vllm rust crates to 6ff479e1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,7 +2637,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 [[package]]
 name = "llm-multimodal"
 version = "1.7.1"
-source = "git+https://github.com/smg-project/llm-multimodal?rev=74f64753e040ade87c9d7f4bb0ad2f4dd7764652#74f64753e040ade87c9d7f4bb0ad2f4dd7764652"
+source = "git+https://github.com/smg-project/llm-multimodal?rev=24c676dd49d73f05cb4068aade2e60397a5c0afe#24c676dd49d73f05cb4068aade2e60397a5c0afe"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6862,12 +6862,12 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 [[package]]
 name = "vllm-build-info"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=60857baa53a743913d4e919f12b5fd8d608ded86#60857baa53a743913d4e919f12b5fd8d608ded86"
+source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
 
 [[package]]
 name = "vllm-chat"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=60857baa53a743913d4e919f12b5fd8d608ded86#60857baa53a743913d4e919f12b5fd8d608ded86"
+source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -6905,7 +6905,7 @@ dependencies = [
 [[package]]
 name = "vllm-engine-core-client"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=60857baa53a743913d4e919f12b5fd8d608ded86#60857baa53a743913d4e919f12b5fd8d608ded86"
+source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6939,7 +6939,7 @@ dependencies = [
 [[package]]
 name = "vllm-llm"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=60857baa53a743913d4e919f12b5fd8d608ded86#60857baa53a743913d4e919f12b5fd8d608ded86"
+source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
 dependencies = [
  "easy-ext",
  "enum-as-inner",
@@ -6959,7 +6959,7 @@ dependencies = [
 [[package]]
 name = "vllm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=60857baa53a743913d4e919f12b5fd8d608ded86#60857baa53a743913d4e919f12b5fd8d608ded86"
+source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
 dependencies = [
  "itertools 0.14.0",
  "prometheus-client",
@@ -6968,7 +6968,7 @@ dependencies = [
 [[package]]
 name = "vllm-parser"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=60857baa53a743913d4e919f12b5fd8d608ded86#60857baa53a743913d4e919f12b5fd8d608ded86"
+source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
 dependencies = [
  "easy-ext",
  "serde",
@@ -6983,7 +6983,7 @@ dependencies = [
 [[package]]
 name = "vllm-server"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=60857baa53a743913d4e919f12b5fd8d608ded86#60857baa53a743913d4e919f12b5fd8d608ded86"
+source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -7039,7 +7039,7 @@ dependencies = [
 [[package]]
 name = "vllm-text"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=60857baa53a743913d4e919f12b5fd8d608ded86#60857baa53a743913d4e919f12b5fd8d608ded86"
+source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -7064,7 +7064,7 @@ dependencies = [
 [[package]]
 name = "vllm-tokenizer"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=60857baa53a743913d4e919f12b5fd8d608ded86#60857baa53a743913d4e919f12b5fd8d608ded86"
+source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
 dependencies = [
  "base64 0.22.1",
  "fastokens",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,11 +179,11 @@ url = { version = "2.5", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 velo = "0.1.0"
-vllm-chat = { git = "https://github.com/vllm-project/vllm.git", rev = "60857baa53a743913d4e919f12b5fd8d608ded86" }
-vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "60857baa53a743913d4e919f12b5fd8d608ded86" }
-vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "60857baa53a743913d4e919f12b5fd8d608ded86" }
-vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "60857baa53a743913d4e919f12b5fd8d608ded86" }
-vllm-tokenizer = { git = "https://github.com/vllm-project/vllm.git", rev = "60857baa53a743913d4e919f12b5fd8d608ded86" }
+vllm-chat = { git = "https://github.com/vllm-project/vllm.git", rev = "6ff479e1f798048829f884b4229f28c9b9b0c8d7" }
+vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "6ff479e1f798048829f884b4229f28c9b9b0c8d7" }
+vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "6ff479e1f798048829f884b4229f28c9b9b0c8d7" }
+vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "6ff479e1f798048829f884b4229f28c9b9b0c8d7" }
+vllm-tokenizer = { git = "https://github.com/vllm-project/vllm.git", rev = "6ff479e1f798048829f884b4229f28c9b9b0c8d7" }
 xxhash-rust = { version = "0.8", features = ["xxh3", "const_xxh3"] }
 zeromq = { version = "0.6.0", default-features = false, features = [
   "tokio-runtime",

--- a/pegainfer-frontend/src/vllm/mod.rs
+++ b/pegainfer-frontend/src/vllm/mod.rs
@@ -378,6 +378,9 @@ where
         chat_template: None,
         default_chat_template_kwargs: None,
         limit_mm_per_prompt: HashMap::new(),
+        // Startup adapters go through the engine-side LoRA channel
+        // (`load_startup_lora_modules`), never the upstream static loader.
+        lora_modules: Vec::new(),
         chat_template_content_format: ChatTemplateContentFormatOption::default(),
         max_logprobs: None,
         language_model_only: true,


### PR DESCRIPTION
## Summary

Bumps the vendored vLLM Rust frontend crates from `60857baa` (2026-09-03) to upstream `main` `6ff479e1` (2026-09-10).

**Invariant changed:** the frontend's model-line coverage. Upstream vllm-project/vllm#56208 adds DeepSeek-V4.1-Flash to the Rust frontend — `deepseek_v41` chat renderer, reasoning parser, DSML tool parser and image-span expansion, all auto-selected from the checkpoint's `model_type`. pegainfer uses `RendererSelection::default()` / `ParserSelection::default()`, so DeepSeek-V4.1 prompts now render and parse without any local wiring.

Other upstream frontend changes riding along: token-attributed reasoning/unified parsing, reasoning-token usage reporting, Mooncake/NIXL KV-connector metrics, coalesced decoded chunks per engine update, strongly typed wire dtypes, normalized HTTP method metric labels.

**Local change:** one new `Config::lora_modules` field (upstream `--lora-modules` static loading). Left empty — pegainfer loads startup adapters through its own engine-side LoRA channel, not the upstream loader.

Not duplicated: last bump was #1031; nothing else on `main` touches the pins.

## Verification (dev container, bumped crates)

- `cargo fmt --all --check` clean, `cargo metadata --locked` ok
- `cargo test --release --locked -p pegainfer-frontend -p pegainfer-sim --lib`: 71 + 6 passed
- `cargo test --release --locked -p pegainfer-sim --test frontend_e2e`: 18 passed
- CPU clippy (`-p pegainfer-build -p pegainfer-frontend -p pegainfer-sim -p kvbm-logical --all-targets -- -D warnings`) clean

Lockfile diff is only the nine `vllm-*` crates plus their `llm-multimodal` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAHsD91bc7dWzaYRDGeADS
