### PR TITLE
chore(frontend): bump vllm rust crates to 295ac4e5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6863,12 +6863,12 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 [[package]]
 name = "vllm-build-info"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
 
 [[package]]
 name = "vllm-chat"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -6906,7 +6906,7 @@ dependencies = [
 [[package]]
 name = "vllm-engine-core-client"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6940,7 +6940,7 @@ dependencies = [
 [[package]]
 name = "vllm-llm"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
 dependencies = [
  "easy-ext",
  "enum-as-inner",
@@ -6960,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "vllm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
 dependencies = [
  "itertools 0.14.0",
  "prometheus-client",
@@ -6969,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "vllm-parser"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
 dependencies = [
  "easy-ext",
  "serde",
@@ -6982,9 +6982,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "vllm-proto"
+version = "0.1.0"
+source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
+dependencies = [
+ "prost",
+ "prost-types",
+ "protox",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+]
+
+[[package]]
 name = "vllm-server"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -7000,9 +7013,7 @@ dependencies = [
  "libc",
  "llm-multimodal",
  "openssl",
- "prost",
  "prost-types",
- "protox",
  "rmpv",
  "serde",
  "serde_json",
@@ -7019,8 +7030,6 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-health",
- "tonic-prost",
- "tonic-prost-build",
  "tower",
  "tower-http",
  "tracing",
@@ -7034,13 +7043,14 @@ dependencies = [
  "vllm-engine-core-client",
  "vllm-llm",
  "vllm-metrics",
+ "vllm-proto",
  "vllm-text",
 ]
 
 [[package]]
 name = "vllm-text"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -7065,7 +7075,7 @@ dependencies = [
 [[package]]
 name = "vllm-tokenizer"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
 dependencies = [
  "base64 0.22.1",
  "fastokens",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,11 +179,11 @@ url = { version = "2.5", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 velo = "0.1.0"
-vllm-chat = { git = "https://github.com/vllm-project/vllm.git", rev = "6ff479e1f798048829f884b4229f28c9b9b0c8d7" }
-vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "6ff479e1f798048829f884b4229f28c9b9b0c8d7" }
-vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "6ff479e1f798048829f884b4229f28c9b9b0c8d7" }
-vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "6ff479e1f798048829f884b4229f28c9b9b0c8d7" }
-vllm-tokenizer = { git = "https://github.com/vllm-project/vllm.git", rev = "6ff479e1f798048829f884b4229f28c9b9b0c8d7" }
+vllm-chat = { git = "https://github.com/vllm-project/vllm.git", rev = "295ac4e52e8a35772b2a63c028f6510e221a65cf" }
+vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "295ac4e52e8a35772b2a63c028f6510e221a65cf" }
+vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "295ac4e52e8a35772b2a63c028f6510e221a65cf" }
+vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "295ac4e52e8a35772b2a63c028f6510e221a65cf" }
+vllm-tokenizer = { git = "https://github.com/vllm-project/vllm.git", rev = "295ac4e52e8a35772b2a63c028f6510e221a65cf" }
 xxhash-rust = { version = "0.8", features = ["xxh3", "const_xxh3"] }
 zeromq = { version = "0.6.0", default-features = false, features = [
   "tokio-runtime",

--- a/docs/subsystems/frontend/frontend-architecture.md
+++ b/docs/subsystems/frontend/frontend-architecture.md
@@ -1,6 +1,6 @@
 # Frontend architecture: pegainfer-frontend and the engine boundary
 
-**TL;DR:** `pegainfer-frontend` owns everything north of the model schedulers: the engine contract, the vLLM protocol stack, and the `ModelLine` dispatch trait. The contract now has two generations living side by side: the **step contract** (`StepOutputs` wire + `RequestLedger` lifecycle + a contract-owned polling driver — Qwen3, Gemma 4 and `pegainfer-sim` are migrated) and the **legacy handle contract** (`EngineHandle` + `TokenEvent` per-request events — glm52/qwen35/kimi-k2/deepseek-v2-lite still launch through it). **Next step: migrate glm52, then delete the legacy contract.**
+**TL;DR:** `pegainfer-frontend` owns everything north of the model schedulers: the engine contract, the vLLM protocol stack, and the `ModelLine` dispatch trait. The contract now has two generations living side by side: the **step contract** (`StepOutputs` wire + `RequestLedger` lifecycle + a contract-owned polling driver — Qwen3, Gemma 4 and `pegainfer-sim` are migrated) and the **legacy handle contract** (`EngineHandle` + `TokenEvent` per-request events — glm52/qwen35/kimi-k2/deepseek-v2-lite still launch through it). The vLLM Rust dependencies are pinned to `295ac4e5`, including the DeepSeek V4/V4.1 tool-argument encoding fix. **Next step: migrate glm52, then delete the legacy contract.**
 
 Last touched: 2026-09
 
@@ -110,3 +110,34 @@ All six lines are onboarded. Adding a model line = write `model_line.rs` in the 
 ## Next step
 
 Migrate glm52 onto the step contract (the multi-scheduler pilot; brings P/D and EP requirements), then qwen35/kimi-k2/deepseek-v2-lite, then delete the legacy contract modules and `LaunchedEngine::Handle`.
+
+## September 2026 upstream dependency refresh
+
+Preparation: read `docs/index.md`, this architecture document, and the previous
+frontend bump (#1040). No open dependency-refresh PR duplicates this work.
+The user authorized updating to latest upstream, opening a PR, and squash merging
+after all CI checks pass.
+
+Plan: pin all five vLLM dependencies to the same current upstream main commit,
+refresh the lockfile, run release frontend/simulator tests and HTTP E2E plus
+formatting and Clippy, then track the PR through CI and merge.
+The invariant is that the production frontend consumes one coherent upstream
+revision, including the official DeepSeek V4/V4.1 tool-argument encoding fix.
+
+Execution: updating `6ff479e1` to `295ac4e52e8a35772b2a63c028f6510e221a65cf`
+(upstream main observed on 2026-09-11). This includes vllm-project/vllm#56260;
+non-object tool arguments are preserved verbatim according to deepseek-recipe.
+The lockfile adds upstream's extracted `vllm-proto` crate; no local API adaptation
+was needed. Incidental resolver changes to unrelated dependency edges were removed.
+
+Validation in the development container:
+
+- `cargo fmt --all -- --check` and locked Cargo metadata passed.
+- Release frontend/simulator library tests: 71 + 6 passed.
+- Release simulator HTTP frontend E2E: 18 passed.
+- Release frontend/simulator Clippy, all targets with `-D warnings`: passed.
+
+Debrief: the dependency refresh compiles and preserves the existing HTTP serving
+contract. The simulated HTTP gate does not establish DeepSeek model accuracy or
+exercise the V4.1 renderer with a real checkpoint; no GPU/model evaluation was run.
+Next action: require all PR CI checks to pass before squash merging.


### PR DESCRIPTION
Update all five vLLM Rust dependencies from `6ff479e1` to `295ac4e52e8a35772b2a63c028f6510e221a65cf`, upstream main observed on 2026-09-11. This picks up vllm-project/vllm#56260: DeepSeek V4/V4.1 assistant tool-call history now preserves non-object or invalid JSON arguments verbatim, matching deepseek-recipe, instead of rejecting the request.

The lockfile includes upstream's extracted `vllm-proto` crate. No local API changes are needed. No open dependency-refresh PR duplicates this update; all vLLM crates remain on one revision.

Validation in the development container:
- Formatting and locked metadata passed.
- Release frontend/simulator library tests: 71 + 6 passed.
- Release simulated frontend HTTP E2E: 18 passed.
- Release frontend/simulator Clippy, all targets with `-D warnings`: passed.

No DeepSeek checkpoint/GPU evaluation was run; the HTTP E2E uses the simulated engine and establishes frontend integration coverage, not model accuracy.
