### PR TITLE
chore(frontend): bump vllm rust crates to 89dbb264

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6863,12 +6863,12 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 [[package]]
 name = "vllm-build-info"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 
 [[package]]
 name = "vllm-chat"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -6906,7 +6906,7 @@ dependencies = [
 [[package]]
 name = "vllm-engine-core-client"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6940,7 +6940,7 @@ dependencies = [
 [[package]]
 name = "vllm-llm"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "easy-ext",
  "enum-as-inner",
@@ -6960,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "vllm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "itertools 0.14.0",
  "prometheus-client",
@@ -6969,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "vllm-parser"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "easy-ext",
  "serde",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "vllm-proto"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "prost",
  "prost-types",
@@ -6997,7 +6997,7 @@ dependencies = [
 [[package]]
 name = "vllm-server"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -7050,7 +7050,7 @@ dependencies = [
 [[package]]
 name = "vllm-text"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -7075,7 +7075,7 @@ dependencies = [
 [[package]]
 name = "vllm-tokenizer"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=295ac4e52e8a35772b2a63c028f6510e221a65cf#295ac4e52e8a35772b2a63c028f6510e221a65cf"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "base64 0.22.1",
  "fastokens",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,11 +179,11 @@ url = { version = "2.5", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 velo = "0.1.0"
-vllm-chat = { git = "https://github.com/vllm-project/vllm.git", rev = "295ac4e52e8a35772b2a63c028f6510e221a65cf" }
-vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "295ac4e52e8a35772b2a63c028f6510e221a65cf" }
-vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "295ac4e52e8a35772b2a63c028f6510e221a65cf" }
-vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "295ac4e52e8a35772b2a63c028f6510e221a65cf" }
-vllm-tokenizer = { git = "https://github.com/vllm-project/vllm.git", rev = "295ac4e52e8a35772b2a63c028f6510e221a65cf" }
+vllm-chat = { git = "https://github.com/vllm-project/vllm.git", rev = "89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d" }
+vllm-engine-core-client = { git = "https://github.com/vllm-project/vllm.git", rev = "89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d" }
+vllm-server = { git = "https://github.com/vllm-project/vllm.git", rev = "89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d" }
+vllm-text = { git = "https://github.com/vllm-project/vllm.git", rev = "89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d" }
+vllm-tokenizer = { git = "https://github.com/vllm-project/vllm.git", rev = "89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d" }
 xxhash-rust = { version = "0.8", features = ["xxh3", "const_xxh3"] }
 zeromq = { version = "0.6.0", default-features = false, features = [
   "tokio-runtime",

--- a/docs/subsystems/frontend/frontend-architecture.md
+++ b/docs/subsystems/frontend/frontend-architecture.md
@@ -113,31 +113,17 @@ Migrate glm52 onto the step contract (the multi-scheduler pilot; brings P/D and 
 
 ## September 2026 upstream dependency refresh
 
-Preparation: read `docs/index.md`, this architecture document, and the previous
-frontend bump (#1040). No open dependency-refresh PR duplicates this work.
-The user authorized updating to latest upstream, opening a PR, and squash merging
-after all CI checks pass.
+All five direct vLLM Rust dependencies and their transitive workspace crates are
+pinned to `89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d` (upstream main observed
+on 2026-09-11). Keeping one revision across these crates preserves the frontend's
+shared protocol and type contract.
 
-Plan: pin all five vLLM dependencies to the same current upstream main commit,
-refresh the lockfile, run release frontend/simulator tests and HTTP E2E plus
-formatting and Clippy, then track the PR through CI and merge.
-The invariant is that the production frontend consumes one coherent upstream
-revision, including the official DeepSeek V4/V4.1 tool-argument encoding fix.
+The only upstream commit since `295ac4e5` is vllm-project/vllm#56447, a Python-side
+GLM-OCR MTP position-masking fix. The Rust crates are unchanged, so this refresh
+does not add that model fix to PegaInfer or require a local API adaptation.
+The DeepSeek V4/V4.1 tool-argument encoding fix from #56260 remains included.
 
-Execution: updating `6ff479e1` to `295ac4e52e8a35772b2a63c028f6510e221a65cf`
-(upstream main observed on 2026-09-11). This includes vllm-project/vllm#56260;
-non-object tool arguments are preserved verbatim according to deepseek-recipe.
-The lockfile adds upstream's extracted `vllm-proto` crate; no local API adaptation
-was needed. Incidental resolver changes to unrelated dependency edges were removed.
-
-Validation in the development container:
-
-- `cargo fmt --all -- --check` and locked Cargo metadata passed.
-- Release frontend/simulator library tests: 71 + 6 passed.
-- Release simulator HTTP frontend E2E: 18 passed.
-- Release frontend/simulator Clippy, all targets with `-D warnings`: passed.
-
-Debrief: the dependency refresh compiles and preserves the existing HTTP serving
-contract. The simulated HTTP gate does not establish DeepSeek model accuracy or
-exercise the V4.1 renderer with a real checkpoint; no GPU/model evaluation was run.
-Next action: require all PR CI checks to pass before squash merging.
+Validation passed: release frontend/simulator library tests (71 + 6), simulated
+HTTP E2E (18), formatting, locked Cargo metadata, and frontend/simulator Clippy
+with warnings denied. The simulated HTTP gate covers frontend integration, not
+GPU execution or model accuracy.


### PR DESCRIPTION
Pin all five vLLM Rust dependencies and their transitive workspace crates to `89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d`, upstream main observed on 2026-09-11. The frontend continues to consume one coherent upstream protocol/type revision.

The sole upstream change since `295ac4e5` is vllm-project/vllm#56447 (Python GLM-OCR MTP position masking). Rust sources are unchanged; this refresh does not introduce that Python model fix into PegaInfer. No open dependency-refresh PR duplicates this update. Refresh the dependency documentation to describe the current pin and validation.

Validation in the development container:
- Formatting and locked Cargo metadata passed.
- Release frontend/simulator library tests: 71 + 6 passed.
- Release simulated HTTP frontend E2E: 18 passed.
- Release frontend/simulator Clippy, all targets with `-D warnings`: passed.

The simulated HTTP gate covers frontend integration; no GPU/model accuracy evaluation was run.
